### PR TITLE
Use travis language minimal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: required
 
+# https://github.com/travis-ci/docs-travis-ci-com/issues/910#issuecomment-356915625
+language: minimal
+
 services:
   - docker
 


### PR DESCRIPTION
The language of minimal point to the same image as bash/sh/shell.
It's smaller than default language ruby.